### PR TITLE
Add download and file preview in result page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/aictron-app/src/assets/style/result.css
+++ b/aictron-app/src/assets/style/result.css
@@ -4,3 +4,8 @@
     font-weight: 700;
     color: var(--primary-orange);
 }
+
+#result .blue-btn {
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/aictron-app/src/assets/style/result.css
+++ b/aictron-app/src/assets/style/result.css
@@ -9,3 +9,53 @@
     margin-left: auto;
     margin-right: auto;
 }
+
+/* Preview CSV */
+#result div#preview {
+    min-width: 30vw;
+    width: 70%;
+    max-width: 70vw;
+    height: 300px; 
+    overflow: auto;
+    
+    border-radius: 10px;
+
+    margin: 3rem auto;
+    filter: drop-shadow(0px 0px 50px rgba(25, 124, 226, 0.1));
+}
+
+#result table {
+    border-collapse: collapse;
+    text-align: left;
+}
+#result table > thead th:first-child {
+    border-radius: 10px 0 0 0;
+}
+#result table > thead th:last-child {
+    border-radius: 0 10px 0 0;
+}
+
+#result table > thead tr {
+    background-color: transparent;
+}
+#result table > thead th {
+    border: none;
+}
+th, td {
+    padding: 1rem;
+    border: 1px solid #444;
+    text-align: left;
+    vertical-align: middle;
+    color: var(--white); 
+}
+th {
+    background-color: #444; 
+    font-weight: bold;
+    text-align: left;
+}
+tr:nth-child(even) {
+    background-color: #333;
+}
+tr:nth-child(odd) {
+    background-color: #222;
+}

--- a/aictron-app/src/pages/Predict/ResultFile.js
+++ b/aictron-app/src/pages/Predict/ResultFile.js
@@ -1,4 +1,5 @@
-import { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
+import Papa from 'papaparse';
 
 import downloadIcon from '../../assets/icons/download.svg';
 import '../../assets/style/result.css';
@@ -6,6 +7,36 @@ import '../../assets/style/result.css';
 const ResultFile = () => {
   const api_dev = "http://localhost:4567";
   const api_prod = "http://api.aictron.arnaudmichel.fr";
+
+  const [tableRows, setTableRows] = useState([]);
+  const [values, setValues] = useState([]);
+
+  useEffect(() => {
+    fetch((api_dev + '/get_predictions'), { method: 'GET' })
+      .then((response) => response.blob())
+      .then((blob) => {
+        Papa.parse(blob, {
+          header: true,
+          skipEmptyLines: true,
+          complete: function (results) {
+            const rowsArray = [];
+            const valuesArray = [];
+
+            // Iterating data to get column name and their values
+            results.data.map((d) => {
+              rowsArray.push(Object.keys(d));
+              valuesArray.push(Object.values(d));
+            });
+
+            setTableRows(rowsArray[0]);
+            setValues(valuesArray);
+          },
+        });
+      })
+      .catch((error) => {
+        console.error('Error downloading file:', error);
+      });
+  }, []);
 
   const handleClick = useCallback(async () => {
     try {
@@ -22,16 +53,43 @@ const ResultFile = () => {
 
       // Remove the link element from the DOM after the download has finished
       URL.revokeObjectURL(link.href);
+
       link.remove();
     } catch (error) {
       console.error('Error downloading file:', error);
     }
   }, []);
+  
 
   return (
       <main id="result" className={"wrap"}>
           <h1>Result ✨</h1>
           <p>Download the predictions and see the future... Thanks for using AIctron !</p>
+          
+          {/* CSV Preview */}
+          <div id="preview">
+            <table>
+              <thead>
+                <tr>
+                  {tableRows.map((rows, index) => {
+                    return <th key={index}>{rows}</th>;
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {values.map((value, index) => {
+                  return (
+                    <tr key={index}>
+                      {value.map((val, i) => {
+                        return <td key={i}>{val}</td>;
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
           <button className={'blue-btn'} onClick={handleClick}><img src={downloadIcon} alt="Download icon"/>Download</button>
       </main>
   );

--- a/aictron-app/src/pages/Predict/ResultFile.js
+++ b/aictron-app/src/pages/Predict/ResultFile.js
@@ -1,17 +1,40 @@
-import React from 'react';
-import {Link} from "react-router-dom";
+import { useCallback } from 'react';
 
 import downloadIcon from '../../assets/icons/download.svg';
 import '../../assets/style/result.css';
 
-const ResultText = () => {
+const ResultFile = () => {
+  const api_dev = "http://localhost:4567";
+  const api_prod = "http://api.aictron.arnaudmichel.fr";
+
+  const handleClick = useCallback(async () => {
+    try {
+      const response = await fetch((api_dev + '/get_predictions'), { method: 'GET' });
+      const blob = await response.blob();
+
+      // Create a temporary link element and set the href to the file URL
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'predictions.csv';
+
+      // Dispatch a click event on the link to start the download
+      link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      // Remove the link element from the DOM after the download has finished
+      URL.revokeObjectURL(link.href);
+      link.remove();
+    } catch (error) {
+      console.error('Error downloading file:', error);
+    }
+  }, []);
+
   return (
       <main id="result" className={"wrap"}>
           <h1>Result ✨</h1>
           <p>Download the predictions and see the future... Thanks for using AIctron !</p>
-          <Link className={'input-btn'}><img src={downloadIcon} alt="Download icon"/>Download</Link>
+          <button className={'blue-btn'} onClick={handleClick}><img src={downloadIcon} alt="Download icon"/>Download</button>
       </main>
   );
 };
 
-export default ResultText;
+export default ResultFile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "papaparse": "^5.4.1"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "papaparse": "^5.4.1"
+  }
+}


### PR DESCRIPTION
# Add download and file preview in result page

## Description
- User can now download the predictions as a .csv file by clicking on Download button.
- A preview of the file is displayed above the Download button.

## Screenshots
![image](https://github.com/Group-3-Charlie/AIctron/assets/69113642/d8160235-bb09-4c7b-b124-90511cc63e3a)

## Checklist
Please check all the following items before submitting your pull request:
- [x] I have tested these changes locally.
- [x] All tests pass.
- [x] My code follows the project's style guidelines.
- [x] I have squashed my commits into meaningful chunks.

## Reviewers
- @MrArnaudMichel 
